### PR TITLE
added some cleanup tweaks

### DIFF
--- a/nao/Dockerfile
+++ b/nao/Dockerfile
@@ -2,9 +2,15 @@ FROM ros:indigo
 MAINTAINER Chris Timperley "christimperley@gmail.com"
 
 ENV ROSVERSION "indigo"
-RUN sudo apt-get update && \
-    sudo apt-get install -y ros-${ROSVERSION}-nao-robot \
+RUN apt-get update && \
+    apt-get --no-install-recommends install -y ros-${ROSVERSION}-nao-robot \
                             ros-${ROSVERSION}-nao-extras && \
-    sudo apt-get clean && \
-    sudo apt-get autoremove && \
-    sudo rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+    apt-get clean && \
+    apt-get autoremove && \
+    && rm -rf \
+        /var/lib/apt/lists/* \
+        /tmp/* \
+        /var/tmp/* \
+        /usr/share/man \
+        /usr/share/doc \
+        /usr/share/doc-base


### PR DESCRIPTION
By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages . 

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

Removed "sudo" as docker best practice at [Docker Blog](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#user) 

Another Cleanup tweaks using 

1. apt-get clean 

2. rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

removing downloaded packages and packages list will free up some space ,

results in smaller image size.